### PR TITLE
Build packages using CircleCI

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -38,9 +38,9 @@ package() {
 	install -D -m644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }
 
-md5sums="d5b0e85eb23ee6721d1ba623f162c6a7  npm-bower-1.7.9.tar.gz
+md5sums="d5b0e85eb23ee6721d1ba623f162c6a7  node-bower-1.7.9.tar.gz
 0bd85677e70f75ba0ac22c2ce7e566ef  10-npm-package-no-prepublish.patch"
-sha256sums="55ff05b6e86a767c04ef5bf3408438bee565862070e13ee0b327af5b76e446f8  npm-bower-1.7.9.tar.gz
+sha256sums="55ff05b6e86a767c04ef5bf3408438bee565862070e13ee0b327af5b76e446f8  node-bower-1.7.9.tar.gz
 5b818f118f80b811308dceef6b9d8f3e054a35828b2e61a5a4684d9a05f11d74  10-npm-package-no-prepublish.patch"
-sha512sums="23a24825d04ac829f3869ca9663f4e70bb0ec46068b99be53a19346dde7ac1be13f28a8f1b7205d71fc6c3d4c938bf2cb8579a6b1266a23a3e118a46b5e64064  npm-bower-1.7.9.tar.gz
+sha512sums="23a24825d04ac829f3869ca9663f4e70bb0ec46068b99be53a19346dde7ac1be13f28a8f1b7205d71fc6c3d4c938bf2cb8579a6b1266a23a3e118a46b5e64064  node-bower-1.7.9.tar.gz
 b906612821e87cbfe8a5f4f350fd7c67df17c99eb64d816658fd25aea9ff3aeaea2a8a62aec2d29d99785c9c0feea7c3cbfe7dfcd15e166a3d5191a365b1fa7f  10-npm-package-no-prepublish.patch"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # alpine-pkg-node-bower
 
+[![CircleCI](https://img.shields.io/circleci/project/sgerrand/alpine-pkg-node-bower/master.svg)](https://circleci.com/gh/sgerrand/alpine-pkg-node-bower)
+
 This is [Bower][bower] as an Alpine Linux package.
 
 [bower]: https://bower.io

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,18 @@
+general:
+  artifacts:
+    - packages
+
+machine:
+  services:
+    - docker
+
+dependencies:
+  pre:
+    - mkdir packages
+    - echo -e "$RSA_PUBLIC_KEY" > packages/sgerrand.rsa.pub
+  override:
+    - docker run -e RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" -e RSA_PRIVATE_KEY_NAME="sgerrand.rsa" -v $(pwd):/home/builder/package -v $(pwd)/packages:/home/builder/packages sgerrand/alpine-abuild:3.4
+
+test:
+  override:
+    - docker run -it -v $(pwd)/packages:/packages alpine:3.4 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"


### PR DESCRIPTION
💁  These changes add CircleCI configuration to automatically build and test packages. Also fixes a lingering invalid package name in the checksums from the original package name.
